### PR TITLE
Fix issues with higher minSdkVersion in consumer

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,7 @@ android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   buildToolsVersion getExtOrDefault('buildToolsVersion')
   defaultConfig {
-    minSdkVersion 16
+    minSdkVersion rootProject.hasProperty('minSdkVersion') ? rootProject.minSdkVersion : 16
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
     versionCode 1
     versionName "1.0"


### PR DESCRIPTION
See: 
https://lifesaver.codes/answer/android-build-fails-for-libs-with-minsdkversion-17-with-react-native-0-64-2712#:~:text=uxcam/react%2Dnative%2Dux%2Dcam%2324%20(comment)
https://github.com/uxcam/react-native-ux-cam/issues/24#issuecomment-892547229